### PR TITLE
Feature/allow setting auth in constructor for #21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.idea

--- a/src/Client.php
+++ b/src/Client.php
@@ -116,15 +116,27 @@ class Client
     /** @var array */
     protected $options = [];
 
-    public function __construct()
+    private $netbox_api = null;
+    private $netbox_token = null;
+
+    public function __construct($netbox_api = null, $netbox_token = null)
     {
-        if (strlen(getenv('NETBOX_API')) === 0 || strlen(getenv('NETBOX_API_KEY')) === 0) {
+        $this->netbox_api = $netbox_api;
+        $this->netbox_token = $netbox_token;
+        if($this->netbox_api === null && strlen(getenv('NETBOX_API')) !== 0) {
+            $this->netbox_api = getenv('NETBOX_API');
+        }
+        if($this->netbox_token === null && strlen(getenv('NETBOX_API_KEY')) !== 0) {
+            $this->netbox_token = getenv('NETBOX_API_KEY');
+        }
+        if ($this->netbox_api === null || $this->netbox_token === null) {
             throw new RuntimeException(
                 sprintf(
-                    'Environment Variables not found (NETBOX_API, NETBOX_API_KEY): "%s" "redacted(%s(%s))"',
-                    getenv('NETBOX_API'),
-                    gettype(getenv('NETBOX_API_KEY')),
-                    strlen(getenv('NETBOX_API_KEY'))
+                    'Client not properly configured (NETBOX_API, NETBOX_API_KEY): "%s" "redacted(%s(%s))". 
+                    Please configure in constructor or environment variables',
+                    $this->netbox_api,
+                    gettype($this->netbox_token),
+                    strlen($this->netbox_token)
                 ),
                 1653901216
             );
@@ -168,7 +180,8 @@ class Client
             $this->httpClient = new HttpClient();
         }
         $this->httpClient->setOptions($this->getOptions());
-
+        $this->httpClient->setBaseUri($this->netbox_api);
+        $this->httpClient->setAuthToken($this->netbox_token);
         return $this->httpClient;
     }
 

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -13,6 +13,14 @@ class HttpClient implements HttpClientInterface
 
     /** @var array */
     protected $options = [];
+    /**
+     * @var string
+     */
+    private $baseUri;
+    /**
+     * @var string
+     */
+    private $authToken;
 
     /**
      * @return Client
@@ -21,7 +29,7 @@ class HttpClient implements HttpClientInterface
     {
         if (!isset($this->client)) {
             $this->client = new Client([
-                'base_uri' => getenv('NETBOX_API'),
+                'base_uri' => $this->baseUri,
                 RequestOptions::TIMEOUT => 180,
                 RequestOptions::COOKIES => true,
                 RequestOptions::CONNECT_TIMEOUT => 180,
@@ -29,7 +37,7 @@ class HttpClient implements HttpClientInterface
                 RequestOptions::HEADERS => [
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json',
-                    'Authorization' => sprintf("Token %s", getenv('NETBOX_API_KEY')),
+                    'Authorization' => sprintf("Token %s", $this->authToken),
                 ]
             ]);
 
@@ -159,5 +167,15 @@ class HttpClient implements HttpClientInterface
     public function setOptions(array $options)
     {
         $this->options = array_merge($this->options, $options);
+    }
+
+    public function setBaseUri(string $uri)
+    {
+        $this->baseUri = $uri;
+    }
+
+    public function setAuthToken(string $token)
+    {
+        $this->authToken = $token;
     }
 }

--- a/src/HttpClient/HttpClientInterface.php
+++ b/src/HttpClient/HttpClientInterface.php
@@ -41,4 +41,7 @@ interface HttpClientInterface
      * @param array $options
      */
     public function setOptions(array $options);
+
+    public function setBaseUri(string $uri);
+    public function setAuthToken(string $token);
 }

--- a/tests/TestAuthorizationConfiguration.php
+++ b/tests/TestAuthorizationConfiguration.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+use mkevenaar\NetBox\Client;
+
+const TESTURL = "https://example.invalid";
+const TESTKEY = "example_api_key";
+function compareGuzzleConfig($config, $testid)
+{
+    $uri = $config['base_uri'];
+    if(TESTURL != $uri) {
+        throw new \Exception("FAIL $testid: uri $uri did not match expected ".TESTURL);
+    }
+    $expectedAuth = 'Token '.TESTKEY;
+    $actualAuth = $config['headers']['Authorization'];
+    if($expectedAuth !== $actualAuth) {
+        throw new \Exception("FAIL $testid: Authorization Header $actualAuth did not match expected Authorization Header $expectedAuth");
+    }
+}
+
+function testSettingAuthWithEnvironmentVariables()
+{
+    putenv('NETBOX_API='.TESTURL);
+    putenv('NETBOX_API_KEY='.TESTKEY);
+    $guzzleClient = (new Client())->getHttpClient()->getClient();
+    $config = $guzzleClient->getConfig();
+    compareGuzzleConfig($config, 'ENV-TEST');
+    echo "ENV-TEST: OK\n";
+    putenv('NETBOX_API=');
+    putenv('NETBOX_API_KEY=');
+
+}
+
+function testSettingAuthWithConstructor()
+{
+    $guzzleClient = (new Client(TESTURL, TESTKEY))->getHttpClient()->getClient();
+    $config = $guzzleClient->getConfig();
+    compareGuzzleConfig($config, 'CONSTRUCTOR-TEST');
+    echo "CONSTRUCTOR-TEST: OK\n";
+}
+
+### Run Tests
+
+testSettingAuthWithConstructor();
+testSettingAuthWithEnvironmentVariables();


### PR DESCRIPTION
Implements the proposed solution in #21

## Description

As described in issue:

- Priorize configuration from constructor if set
- use environment variables if not set in constructor


## Related Issue
https://github.com/mkevenaar/netbox-php/issues/21

## Motivation and Context

-  Using this library inside a symfony project. The way how environment variables are configured in symfony and are read by this library are not compatible.
- Using constructor parameters has better compatibility with dependency injection frameworks

## How Has This Been Tested?

- Tests are located in tests/TestAuthorizationConfiguration.php
- Did not want to impose phpunit as a new dependency on the project. Therefore the tests are a bit crude.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
