### PR TITLE
replace getenv('NETBOX_API') with baseuri property for http client

### DIFF
--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -68,7 +68,7 @@ class HttpClient implements HttpClientInterface
     {
         $response = $this->getClient()->request(
             'GET',
-            getenv('NETBOX_API') . $path,
+            $this->baseUri . $path,
             [
                 'query' => $query
             ]
@@ -87,7 +87,7 @@ class HttpClient implements HttpClientInterface
     {
         $response = $this->getClient()->request(
             'POST',
-            getenv('NETBOX_API') . $path,
+            $this->baseUri . $path,
             [
                 'json' => $body
             ]
@@ -106,7 +106,7 @@ class HttpClient implements HttpClientInterface
     {
         $response = $this->getClient()->request(
             'PUT',
-            getenv('NETBOX_API') . $path,
+            $this->baseUri . $path,
             [
                 'json' => $body
             ]
@@ -125,7 +125,7 @@ class HttpClient implements HttpClientInterface
     {
         $response = $this->getClient()->request(
             'PATCH',
-            getenv('NETBOX_API') . $path,
+            $this->baseUri . $path,
             [
                 'json' => $body
             ]
@@ -144,7 +144,7 @@ class HttpClient implements HttpClientInterface
     {
         $response = $this->getClient()->request(
             'DELETE',
-            getenv('NETBOX_API') . $path,
+            $this->baseUri . $path,
             [
                 'json' => $body
             ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Bugfix for https://github.com/mkevenaar/netbox-php/pull/22

I've only looked at the configuration of the client. Overlooked that the env variable is also used when crafting requests. This PR fixes that, so the HTTP Client uses the baseUri property. (Which in turn gets set higher up in the chain from either env or constructor parameter)

## Related Issue

https://github.com/mkevenaar/netbox-php/pull/22
https://github.com/mkevenaar/netbox-php/issues/21

